### PR TITLE
fix: reset life when try again

### DIFF
--- a/src/components/ScoreBoard.vue
+++ b/src/components/ScoreBoard.vue
@@ -39,6 +39,9 @@ watch(() => score.value, () => {
 
 let showPromotion = ref(false)
 watch(() => title.value[1], (to, from) => {
+  if(score.value === 0) {
+    return
+  }
   if (to !== 'JavaScript Learner') {
     showPromotion.value = true
   }


### PR DESCRIPTION
Hello,

I observed that the life doesn't seem to reset upon retrying.
It should ideally be 60, even after being promoted previously.
Just wanted to bring this to your attention.
By the way, I absolutely adore this game! ❤️
Thank you so much for crafting such a delightful experience.

Warm regards,
Melody.